### PR TITLE
fix: avoid building simd on wasm32-wasi. vendor pest with submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third-party/pest"]
+	path = third-party/pest
+	url = https://github.com/dylibso/pest.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,28 @@ version = "0.1.0"
 circle-ci = { repository = "HewlettPackard/dockerfile-parser-rs", branch = "master" }
 
 [dependencies]
-pest = "2.1"
-pest_derive = "2.1"
 snafu = "0.6"
 enquote = "1.1"
 regex = "1.5"
 lazy_static = "1.4"
+
+[dependencies.pest]
+version = "2.1"
+default-features = false
+features = ["std"]
+path = "third-party/pest/pest"
+
+[dependencies.pest_derive]
+version = "2.1"
+path = "third-party/pest/derive"
+
+# regex uses memchr which usually pulls in simd
+# but in this case appears not too.
+# uncomment below to avoid pulling in memchr
+#[dependencies.regex]
+#version = "1.5"
+#default-features = false
+#features = []
 
 [dev-dependencies]
 indoc = "1.0"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ performing static analysis, writing linters, and creating automated tooling
 around Dockerfiles. It uses a proper grammar and can provide useful syntax
 errors in addition to a full syntax tree.
 
+## Setup
+
+`git submodule update --init --recursive`
+
+`cd third-party/pest && cargo build --package pest_bootstrap`
+
 ## Limitations
 
  * Buildkit parser directives are not handled at all.


### PR DESCRIPTION
Disabling `memchr` feature in pest doesn't stop the `memchr` "optional" dep from being pulled in. pest was forked to remove the `memchr` dependency so this can be built without generating simd instructions on `wasm32-wasi`.